### PR TITLE
Enable middleware by default

### DIFF
--- a/middlewares/expoCron/default.json
+++ b/middlewares/expoCron/default.json
@@ -1,0 +1,5 @@
+{
+  "expoCron": {
+    "enabled": true
+  }
+}


### PR DESCRIPTION
Cut's down on the number of steps required to install the plugin as this should remove the need to have the user add in the setting to `./config/middleware.js`