### PR TITLE
Fix relation and error on default total and default total value type

### DIFF
--- a/models/exponotification.settings.json
+++ b/models/exponotification.settings.json
@@ -8,7 +8,10 @@
   },
   "options": {
     "increments": true,
-    "timestamps": ["created_at", "updated_at"],
+    "timestamps": [
+      "created_at",
+      "updated_at"
+    ],
     "comment": "",
     "draftAndPublish": true
   },
@@ -31,13 +34,23 @@
     },
     "platform": {
       "type": "enumeration",
-      "enum": ["all", "android", "ios"],
+      "enum": [
+        "all",
+        "android",
+        "ios"
+      ],
       "default": "all",
       "required": true
     },
     "status": {
       "type": "enumeration",
-      "enum": ["pending", "waiting", "finished", "canceled", "failed"],
+      "enum": [
+        "pending",
+        "waiting",
+        "finished",
+        "canceled",
+        "failed"
+      ],
       "default": "pending",
       "required": true
     },

--- a/models/exponotification.settings.json
+++ b/models/exponotification.settings.json
@@ -8,10 +8,7 @@
   },
   "options": {
     "increments": true,
-    "timestamps": [
-      "created_at",
-      "updated_at"
-    ],
+    "timestamps": ["created_at", "updated_at"],
     "comment": "",
     "draftAndPublish": true
   },
@@ -34,29 +31,19 @@
     },
     "platform": {
       "type": "enumeration",
-      "enum": [
-        "all",
-        "android",
-        "ios"
-      ],
+      "enum": ["all", "android", "ios"],
       "default": "all",
       "required": true
     },
     "status": {
       "type": "enumeration",
-      "enum": [
-        "pending",
-        "waiting",
-        "finished",
-        "canceled",
-        "failed"
-      ],
+      "enum": ["pending", "waiting", "finished", "canceled", "failed"],
       "default": "pending",
       "required": true
     },
     "total": {
       "type": "integer",
-      "default": "0"
+      "default": 0
     },
     "users": {
       "collection": "user",

--- a/models/expotoken.settings.json
+++ b/models/expotoken.settings.json
@@ -8,10 +8,7 @@
   },
   "options": {
     "increments": true,
-    "timestamps": [
-      "created_at",
-      "updated_at"
-    ],
+    "timestamps": ["created_at", "updated_at"],
     "comment": "",
     "draftAndPublish": false
   },
@@ -23,15 +20,11 @@
     },
     "platform": {
       "type": "enumeration",
-      "enum": [
-        "android",
-        "ios"
-      ]
+      "enum": ["android", "ios"]
     },
     "user": {
       "plugin": "users-permissions",
-      "model": "user",
-      "via": "expotokens"
+      "model": "user"
     }
   }
 }

--- a/models/expotoken.settings.json
+++ b/models/expotoken.settings.json
@@ -8,7 +8,10 @@
   },
   "options": {
     "increments": true,
-    "timestamps": ["created_at", "updated_at"],
+    "timestamps": [
+      "created_at",
+      "updated_at"
+    ],
     "comment": "",
     "draftAndPublish": false
   },
@@ -20,7 +23,10 @@
     },
     "platform": {
       "type": "enumeration",
-      "enum": ["android", "ios"]
+      "enum": [
+        "android",
+        "ios"
+      ]
     },
     "user": {
       "plugin": "users-permissions",


### PR DESCRIPTION
Signed-off-by: Derrick Mehaffy <derrickmehaffy@gmail.com>

Modified relation to be a oneWay instead of a oneToOne (not sure if this will work entirely as I haven't fully tested the plugin yet)

Also fixed an issue when creating a notification without any tokens which would try to write a string `"0"` instead of an integer `0`